### PR TITLE
fix/ CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,17 @@
 version: 2.1
+
+executors:
+  machine-executor:
+    machine:
+      image: ubuntu-2004:202107-02
+
 jobs:
   build:
-    docker:
-      - image: buildpack-deps:trusty
+    executor:
+      name: machine-executor
 
     steps:
       - checkout
-
-      - run:
-          name: Install docker-compose
-          command: |
-            set -x
-            curl -L https://github.com/docker/compose/releases/download/1.26.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-            chmod +x /usr/local/bin/docker-compose
-
-      - setup_remote_docker
 
       - run:
           name: Build Docker
@@ -22,8 +19,7 @@ jobs:
 
       - run:
           name: Docker-compose up
-          command:
-            docker-compose up -d
+          command: docker-compose up -d
 
       - run:
           name: Finish message

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,11 @@ jobs:
 
       - run:
           name: Build Docker
-          command: docker-compose build
+          command: docker compose build
 
       - run:
-          name: Docker-compose up
-          command: docker-compose up -d
+          name: Docker Compose up
+          command: docker compose up -d
 
       - run:
           name: Finish message

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,11 @@ jobs:
 
       - run:
           name: Build Docker
-          command: docker compose build
+          command: docker-compose build
 
       - run:
-          name: Docker Compose up
-          command: docker compose up -d
+          name: Docker-compose up
+          command: docker-compose up -d
 
       - run:
           name: Finish message


### PR DESCRIPTION
# About

Use docker of machine executor to resolve the following CI error;

> ERROR: You're using an RSA key with SHA-1, which is no longer allowed

## Ref

- about error
  - https://discuss.circleci.com/t/discussion-and-resolution-for-error-youre-using-an-rsa-key-with-sha-1-which-is-no-longer-allowed/42572
  - https://github.blog/2021-09-01-improving-git-protocol-security-github/

- about machine executor 
  - https://circleci.com/docs/ja/docker-compose/
  - https://github.com/miolab/kokuraex/blob/main/.circleci/config.yml
