### PR TITLE
[WIP] prepaing install pycaret allow-prerelease

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1848,7 +1848,6 @@ files = [
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
-    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
@@ -2610,42 +2609,42 @@ tests = ["black (>=22.3.0)", "flake8 (>=3.8.2)", "matplotlib (>=3.1.3)", "mypy (
 
 [[package]]
 name = "scipy"
-version = "1.9.3"
+version = "1.10.0"
 description = "Fundamental algorithms for scientific computing in Python"
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = "<3.12,>=3.8"
 files = [
-    {file = "scipy-1.9.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1884b66a54887e21addf9c16fb588720a8309a57b2e258ae1c7986d4444d3bc0"},
-    {file = "scipy-1.9.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:83b89e9586c62e787f5012e8475fbb12185bafb996a03257e9675cd73d3736dd"},
-    {file = "scipy-1.9.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a72d885fa44247f92743fc20732ae55564ff2a519e8302fb7e18717c5355a8b"},
-    {file = "scipy-1.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d01e1dd7b15bd2449c8bfc6b7cc67d630700ed655654f0dfcf121600bad205c9"},
-    {file = "scipy-1.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:68239b6aa6f9c593da8be1509a05cb7f9efe98b80f43a5861cd24c7557e98523"},
-    {file = "scipy-1.9.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b41bc822679ad1c9a5f023bc93f6d0543129ca0f37c1ce294dd9d386f0a21096"},
-    {file = "scipy-1.9.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:90453d2b93ea82a9f434e4e1cba043e779ff67b92f7a0e85d05d286a3625df3c"},
-    {file = "scipy-1.9.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c06e62a390a9167da60bedd4575a14c1f58ca9dfde59830fc42e5197283dab"},
-    {file = "scipy-1.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abaf921531b5aeaafced90157db505e10345e45038c39e5d9b6c7922d68085cb"},
-    {file = "scipy-1.9.3-cp311-cp311-win_amd64.whl", hash = "sha256:06d2e1b4c491dc7d8eacea139a1b0b295f74e1a1a0f704c375028f8320d16e31"},
-    {file = "scipy-1.9.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5a04cd7d0d3eff6ea4719371cbc44df31411862b9646db617c99718ff68d4840"},
-    {file = "scipy-1.9.3-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:545c83ffb518094d8c9d83cce216c0c32f8c04aaf28b92cc8283eda0685162d5"},
-    {file = "scipy-1.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d54222d7a3ba6022fdf5773931b5d7c56efe41ede7f7128c7b1637700409108"},
-    {file = "scipy-1.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cff3a5295234037e39500d35316a4c5794739433528310e117b8a9a0c76d20fc"},
-    {file = "scipy-1.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:2318bef588acc7a574f5bfdff9c172d0b1bf2c8143d9582e05f878e580a3781e"},
-    {file = "scipy-1.9.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d644a64e174c16cb4b2e41dfea6af722053e83d066da7343f333a54dae9bc31c"},
-    {file = "scipy-1.9.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:da8245491d73ed0a994ed9c2e380fd058ce2fa8a18da204681f2fe1f57f98f95"},
-    {file = "scipy-1.9.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4db5b30849606a95dcf519763dd3ab6fe9bd91df49eba517359e450a7d80ce2e"},
-    {file = "scipy-1.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c68db6b290cbd4049012990d7fe71a2abd9ffbe82c0056ebe0f01df8be5436b0"},
-    {file = "scipy-1.9.3-cp39-cp39-win_amd64.whl", hash = "sha256:5b88e6d91ad9d59478fafe92a7c757d00c59e3bdc3331be8ada76a4f8d683f58"},
-    {file = "scipy-1.9.3.tar.gz", hash = "sha256:fbc5c05c85c1a02be77b1ff591087c83bc44579c6d2bd9fb798bb64ea5e1a027"},
+    {file = "scipy-1.10.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b901b423c91281a974f6cd1c36f5c6c523e665b5a6d5e80fcb2334e14670eefd"},
+    {file = "scipy-1.10.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:16ba05d3d1b9f2141004f3f36888e05894a525960b07f4c2bfc0456b955a00be"},
+    {file = "scipy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:151f066fe7d6653c3ffefd489497b8fa66d7316e3e0d0c0f7ff6acca1b802809"},
+    {file = "scipy-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f9ea0a37aca111a407cb98aa4e8dfde6e5d9333bae06dfa5d938d14c80bb5c3"},
+    {file = "scipy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:27e548276b5a88b51212b61f6dda49a24acf5d770dff940bd372b3f7ced8c6c2"},
+    {file = "scipy-1.10.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:42ab8b9e7dc1ebe248e55f54eea5307b6ab15011a7883367af48dd781d1312e4"},
+    {file = "scipy-1.10.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e096b062d2efdea57f972d232358cb068413dc54eec4f24158bcbb5cb8bddfd8"},
+    {file = "scipy-1.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4df25a28bd22c990b22129d3c637fd5c3be4b7c94f975dca909d8bab3309b694"},
+    {file = "scipy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ad449db4e0820e4b42baccefc98ec772ad7818dcbc9e28b85aa05a536b0f1a2"},
+    {file = "scipy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:6faf86ef7717891195ae0537e48da7524d30bc3b828b30c9b115d04ea42f076f"},
+    {file = "scipy-1.10.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:4bd0e3278126bc882d10414436e58fa3f1eca0aa88b534fcbf80ed47e854f46c"},
+    {file = "scipy-1.10.0-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:38bfbd18dcc69eeb589811e77fae552fa923067fdfbb2e171c9eac749885f210"},
+    {file = "scipy-1.10.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ab2a58064836632e2cec31ca197d3695c86b066bc4818052b3f5381bfd2a728"},
+    {file = "scipy-1.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cd7a30970c29d9768a7164f564d1fbf2842bfc77b7d114a99bc32703ce0bf48"},
+    {file = "scipy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:9b878c671655864af59c108c20e4da1e796154bd78c0ed6bb02bc41c84625686"},
+    {file = "scipy-1.10.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:3afcbddb4488ac950ce1147e7580178b333a29cd43524c689b2e3543a080a2c8"},
+    {file = "scipy-1.10.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:6e4497e5142f325a5423ff5fda2fff5b5d953da028637ff7c704378c8c284ea7"},
+    {file = "scipy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:441cab2166607c82e6d7a8683779cb89ba0f475b983c7e4ab88f3668e268c143"},
+    {file = "scipy-1.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0490dc499fe23e4be35b8b6dd1e60a4a34f0c4adb30ac671e6332446b3cbbb5a"},
+    {file = "scipy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:954ff69d2d1bf666b794c1d7216e0a746c9d9289096a64ab3355a17c7c59db54"},
+    {file = "scipy-1.10.0.tar.gz", hash = "sha256:c8b3cbc636a87a89b770c6afc999baa6bcbb01691b5ccbbc1b1791c7c0a07540"},
 ]
 
 [package.dependencies]
-numpy = ">=1.18.5,<1.26.0"
+numpy = ">=1.19.5,<1.27.0"
 
 [package.extras]
-dev = ["flake8", "mypy", "pycodestyle", "typing_extensions"]
-doc = ["matplotlib (>2)", "numpydoc", "pydata-sphinx-theme (==0.9.0)", "sphinx (!=4.1.0)", "sphinx-panels (>=0.5.2)", "sphinx-tabs"]
-test = ["asv", "gmpy2", "mpmath", "pytest", "pytest-cov", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+dev = ["click", "doit (>=0.36.0)", "flake8", "mypy", "pycodestyle", "pydevtool", "rich-click", "typing_extensions"]
+doc = ["matplotlib (>2)", "numpydoc", "pydata-sphinx-theme (==0.9.0)", "sphinx (!=4.1.0)", "sphinx-design (>=0.2.0)"]
+test = ["asv", "gmpy2", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
 name = "seaborn"
@@ -2688,14 +2687,14 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "66.1.1"
+version = "67.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
+    {file = "setuptools-67.0.0-py3-none-any.whl", hash = "sha256:9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d"},
+    {file = "setuptools-67.0.0.tar.gz", hash = "sha256:883131c5b6efa70b9101c7ef30b2b7b780a4283d5fc1616383cdf22c83cbefe6"},
 ]
 
 [package.extras]
@@ -3134,5 +3133,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "ed96957c0eb0b4b1714b23ea332efe58b030abbee17bcc851f591bda48bf5206"
+python-versions = ">=3.8, <3.11"
+content-hash = "3f20dd789d89db39a4f606be7af65eb7c1e0b5fcdfc89eea76679136e367cdcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,17 @@ description = "Environment JupyterLab Poetry docker-compose"
 authors = ["imaima"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8, <3.11"
 
 jupyterlab = "^3.5"
 pandas = "^1.5"
-scikit-learn = "^1.2"
+scikit-learn = ">=1.1.3"
 pyclustering = "^0.10"
 matplotlib = "^3.6"
 seaborn = "^0.12"
 japanize-matplotlib = "^1.1"
 sympy = "^1.11"
-scipy = "^1.9"
+scipy = ">=1.8"
 pandas-datareader = "~0.10"
 numpy = "~1.23.0"
 xgboost = "^1.7.3"


### PR DESCRIPTION
WIP

- ok
```
docker compose run eda poetry add "scikit-learn>=1.1.3"
```

- in progress
```
docker compose run eda poetry add --allow-prereleases pycaret@^3.0.0rc1 --dry-run

 Because no versions of pycaret match >3.0.0rc1,<3.0.0rc2 || >3.0.0rc2,<3.0.0rc3 || >3.0.0rc3,<3.0.0rc4 || >3.0.0rc4,<3.0.0rc5 || >3.0.0rc5,<3.0.0rc6 || >3.0.0rc6,<3.0.0rc7 || >3.0.0rc7,<3.0.0rc8 || >3.0.0rc8,<4.0.0
 and pycaret (3.0.0rc1) depends on pandas (>=1.3.0,<1.5.0), pycaret (>=3.0.0rc1,<3.0.0rc2 || >3.0.0rc2,<3.0.0rc3 || >3.0.0rc3,<3.0.0rc4 || >3.0.0rc4,<3.0.0rc5 || >3.0.0rc5,<3.0.0rc6 || >3.0.0rc6,<3.0.0rc7 || >3.0.0rc7,<3.0.0rc8 || >3.0.0rc8,<4.0.0) requires pandas (>=1.3.0,<1.5.0).
    And because pycaret (3.0.0rc2) depends on pandas (>=1.3.0,<1.5.0), pycaret (>=3.0.0rc1,<3.0.0rc3 || >3.0.0rc3,<3.0.0rc4 || >3.0.0rc4,<3.0.0rc5 || >3.0.0rc5,<3.0.0rc6 || >3.0.0rc6,<3.0.0rc7 || >3.0.0rc7,<3.0.0rc8 || >3.0.0rc8,<4.0.0) requires pandas (>=1.3.0,<1.5.0).
    And because pycaret (3.0.0rc3) depends on pandas (>=1.3.0,<1.5.0)
 and pycaret (3.0.0rc4) depends on pandas (>=1.3.0,<1.5.0), pycaret (>=3.0.0rc1,<3.0.0rc5 || >3.0.0rc5,<3.0.0rc6 || >3.0.0rc6,<3.0.0rc7 || >3.0.0rc7,<3.0.0rc8 || >3.0.0rc8,<4.0.0) requires pandas (>=1.3.0,<1.5.0).
    And because pycaret (3.0.0rc5) depends on numba (>=0.55.0)
 and pycaret (3.0.0rc6) depends on numba (>=0.55.0), pycaret (>=3.0.0rc1,<3.0.0rc7 || >3.0.0rc7,<3.0.0rc8 || >3.0.0rc8,<4.0.0) requires pandas (>=1.3.0,<1.5.0) or numba (>=0.55.0).
(1) So, because pycaret (3.0.0rc7) depends on numba (>=0.55.0)
 and pycaret (3.0.0rc8) depends on numba (>=0.55.0), pycaret (>=3.0.0rc1,<4.0.0) requires pandas (>=1.3.0,<1.5.0) or numba (>=0.55.0).

    Because numba (0.56.3) depends on llvmlite (>=0.39.0dev0,<0.40)
 and numba (0.56.2) depends on llvmlite (>=0.39.0dev0,<0.40), numba (0.56.2 || 0.56.3) requires llvmlite (>=0.39.0dev0,<0.40).
    And because numba (0.56.0) depends on numpy (>=1.18,<1.23)
 and numba (0.55.2) depends on numpy (>=1.18,<1.23), numba (0.55.2 || 0.56.0 || 0.56.2 || 0.56.3) requires llvmlite (>=0.39.0dev0,<0.40) or numpy (>=1.18,<1.23).
    And because numba (0.55.1) depends on numpy (>=1.18,<1.22)
 and numba (0.55.0) depends on numpy (>=1.18,<1.22), numba (0.55.0 || 0.55.1 || 0.55.2 || 0.56.0 || 0.56.2 || 0.56.3) requires llvmlite (>=0.39.0dev0,<0.40) or numpy (>=1.18,<1.23).
    And because no versions of numba match >0.55.0,<0.55.1 || >0.55.1,<0.55.2 || >0.55.2,<0.56.0 || >0.56.0,<0.56.2 || >0.56.2,<0.56.3 || >0.56.3,<0.56.4 || >0.56.4
 and numba (0.56.4) depends on llvmlite (>=0.39.0dev0,<0.40), numba (>=0.55.0) requires llvmlite (>=0.39.0dev0,<0.40) or numpy (>=1.18,<1.23).
    And because pycaret (>=3.0.0rc1,<4.0.0) requires pandas (>=1.3.0,<1.5.0) or numba (>=0.55.0) (1), pycaret (>=3.0.0rc1,<4.0.0) requires pandas (>=1.3.0,<1.5.0) or llvmlite (>=0.39.0dev0,<0.40) or numpy (>=1.18,<1.23)
    And because jupyterlab-docker depends on both pandas (^1.5) and numpy (~1.23.0), pycaret (>=3.0.0rc1,<4.0.0) requires llvmlite (>=0.39.0dev0,<0.40).
    So, because jupyterlab-docker depends on both llvmlite (0.31.0) and pycaret (^3.0.0rc1), version solving failed.
```
